### PR TITLE
task/최초 이슈 타입이 없을 때 자동 생성 #26

### DIFF
--- a/src/main/java/com/project/voa/controller/IssueTypeController.java
+++ b/src/main/java/com/project/voa/controller/IssueTypeController.java
@@ -13,7 +13,7 @@ public class IssueTypeController {
 	private final IssueTypeService issueTypeService;
 
 	@Operation(summary = "이슈유형들 조회", description = "이슈유형들을 조회합니다.")
-	@PostMapping("/issueTypes")
+	@GetMapping("/issueTypes")
 	public ResponseEntity<Object> getIssueTypes() {
 		return new ResponseEntity<>(issueTypeService.getIssueTypes(), HttpStatus.OK);
 	}

--- a/src/main/java/com/project/voa/controller/IssueTypeController.java
+++ b/src/main/java/com/project/voa/controller/IssueTypeController.java
@@ -12,10 +12,9 @@ import org.springframework.web.bind.annotation.*;
 public class IssueTypeController {
 	private final IssueTypeService issueTypeService;
 
-	@Operation(summary = "이슈유형 생성", description = "이슈유형을 생성합니다.")
-	@PostMapping("/issueType")
-	public ResponseEntity<Object> createIssue() {
-		issueTypeService.create();
-		return new ResponseEntity<>(HttpStatus.OK);
+	@Operation(summary = "이슈유형들 조회", description = "이슈유형들을 조회합니다.")
+	@PostMapping("/issueTypes")
+	public ResponseEntity<Object> getIssueTypes() {
+		return new ResponseEntity<>(issueTypeService.getIssueTypes(), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/project/voa/dto/IssueTypeModel.java
+++ b/src/main/java/com/project/voa/dto/IssueTypeModel.java
@@ -1,0 +1,27 @@
+package com.project.voa.dto;
+
+import com.project.voa.domain.IssueType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class IssueTypeModel {
+	private String id;
+	private String name;
+
+	public static IssueTypeModel of(IssueType issueType) {
+		return IssueTypeModel.builder()
+				.id(String.valueOf(issueType.getId()))
+				.name(issueType.getName())
+				.build();
+	}
+
+	public static List<IssueTypeModel> issueTypesToIssueTypeModels(List<IssueType> issueTypes) {
+		return issueTypes.stream()
+				.map(IssueTypeModel::of)
+				.toList();
+	}
+}

--- a/src/main/java/com/project/voa/service/IssueTypeService.java
+++ b/src/main/java/com/project/voa/service/IssueTypeService.java
@@ -1,11 +1,11 @@
 package com.project.voa.service;
 
 import com.project.voa.domain.IssueType;
+import com.project.voa.dto.IssueTypeModel;
 import com.project.voa.repository.IssueTypeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -14,28 +14,11 @@ public class IssueTypeService {
 	private final IssueTypeRepository issueTypeRepository;
 
 	/**
-	 * issueType 생성
+	 * 이슈 유형들 조회
+	 * @return
 	 */
-	public void create() {
-		// TODO 파라미터 하드코딩
-		List<IssueType> listIssueType = new ArrayList<>();
-
-		IssueType issueType = new IssueType();
-		issueType.setName("버그");
-		listIssueType.add(issueType);
-
-		issueType = new IssueType();
-		issueType.setName("작업");
-		listIssueType.add(issueType);
-
-		issueType = new IssueType();
-		issueType.setName("개선사항");
-		listIssueType.add(issueType);
-
-		issueType = new IssueType();
-		issueType.setName("스토리");
-		listIssueType.add(issueType);
-
-		issueTypeRepository.saveAll(listIssueType);
+	public List<IssueTypeModel> getIssueTypes() {
+		List<IssueType> issueTypes = (List<IssueType>) issueTypeRepository.findAll();
+		return IssueTypeModel.issueTypesToIssueTypeModels(issueTypes);
 	}
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+-- 이슈 유형 데이터 자동 추가
+INSERT INTO issue_type (name, created_at, last_modified_at)
+VALUES ('버그', now(), now()),
+       ('작업', now(), now()),
+       ('개선사항', now(), now()),
+       ('스토리', now(), now());


### PR DESCRIPTION
[작업 내용]
- DB를 최초 구축할 때 data.sql 내용을 보고 issue_type 데이터를 자동으로 삽입해줍니다.
- 최초 DB 구축할 때만 application.yml에서 설정하면 됩니다. 
-- 설정방법은 #26 이슈에 적혀있습니다.

+추가작업
- issue_type 생성 API 제거
- issue_type들을 조회하는 API 추가

(issue_type에 데이터가 있으면 데이터를 쌓지 않도록 하면 좋겠지만 그 방법은 추후  더 찾아보겠습니다.)