### PR TITLE
task/레이블 조회 api 구현 #9

### DIFF
--- a/src/main/java/com/project/voa/controller/LabelController.java
+++ b/src/main/java/com/project/voa/controller/LabelController.java
@@ -1,0 +1,20 @@
+package com.project.voa.controller;
+
+import com.project.voa.service.LabelService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class LabelController {
+	private final LabelService labelService;
+
+	@Operation(summary = "labels 조회")
+	@GetMapping("/labels")
+	public ResponseEntity<Object> getLabels() {
+		return new ResponseEntity<>(labelService.getLabels(), HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/project/voa/controller/LabelController.java
+++ b/src/main/java/com/project/voa/controller/LabelController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 public class LabelController {
 	private final LabelService labelService;
 
-	@Operation(summary = "labels 조회")
+	@Operation(summary = "label들 조회")
 	@GetMapping("/labels")
 	public ResponseEntity<Object> getLabels() {
 		return new ResponseEntity<>(labelService.getLabels(), HttpStatus.OK);

--- a/src/main/java/com/project/voa/controller/VersionController.java
+++ b/src/main/java/com/project/voa/controller/VersionController.java
@@ -32,4 +32,10 @@ public class VersionController {
 			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
 		}
 	}
+
+	@Operation(summary = "버전들 조회")
+	@GetMapping("/versions")
+	public ResponseEntity<Object> getVersions() {
+		return new ResponseEntity<>(versionService.getVersions(), HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/project/voa/domain/Issue.java
+++ b/src/main/java/com/project/voa/domain/Issue.java
@@ -23,7 +23,6 @@ public class Issue extends BaseTimeEntity {
 	@ManyToOne
 	private IssueType issueType;
 
-	@Getter
 	@Column(length = 100, nullable = false)
 	private String title;
 

--- a/src/main/java/com/project/voa/dto/LabelModel.java
+++ b/src/main/java/com/project/voa/dto/LabelModel.java
@@ -1,0 +1,27 @@
+package com.project.voa.dto;
+
+import com.project.voa.domain.Label;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class LabelModel {
+	private String id;
+	private String name;
+
+	public static LabelModel of(Label label) {
+		return LabelModel.builder()
+				.id(String.valueOf(label.getId()))
+				.name(label.getName())
+				.build();
+	}
+
+	public static List<LabelModel> labelsToLabelModelList(List<Label> labels) {
+		return labels.stream()
+				.map(LabelModel::of)
+				.toList();
+	}
+}

--- a/src/main/java/com/project/voa/dto/VersionModel.java
+++ b/src/main/java/com/project/voa/dto/VersionModel.java
@@ -1,0 +1,25 @@
+package com.project.voa.dto;
+
+import com.project.voa.domain.Version;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class VersionModel {
+	private String id;
+	private String name;
+
+	public static VersionModel of(Version version) {
+		return VersionModel.builder()
+				.id(String.valueOf(version.getId()))
+				.name(version.getName())
+				.build();
+	}
+
+	public static List<VersionModel> versionsToVersionModels(List<Version> versions) {
+		return versions.stream().map(VersionModel::of).toList();
+	}
+}

--- a/src/main/java/com/project/voa/service/LabelService.java
+++ b/src/main/java/com/project/voa/service/LabelService.java
@@ -1,9 +1,12 @@
 package com.project.voa.service;
 
 import com.project.voa.domain.Label;
+import com.project.voa.dto.LabelModel;
 import com.project.voa.repository.LabelRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -11,10 +14,10 @@ public class LabelService {
 	private final LabelRepository labelRepository;
 
 	/**
-	 * labels 조회
+	 * label들 조회
 	 * @return
 	 */
-	public Iterable<Label> getLabels() {
-		return labelRepository.findAll();
+	public List<LabelModel> getLabels() {
+		return LabelModel.labelsToLabelModelList((List<Label>) labelRepository.findAll());
 	}
 }

--- a/src/main/java/com/project/voa/service/LabelService.java
+++ b/src/main/java/com/project/voa/service/LabelService.java
@@ -1,0 +1,20 @@
+package com.project.voa.service;
+
+import com.project.voa.domain.Label;
+import com.project.voa.repository.LabelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LabelService {
+	private final LabelRepository labelRepository;
+
+	/**
+	 * labels 조회
+	 * @return
+	 */
+	public Iterable<Label> getLabels() {
+		return labelRepository.findAll();
+	}
+}

--- a/src/main/java/com/project/voa/service/VersionService.java
+++ b/src/main/java/com/project/voa/service/VersionService.java
@@ -1,10 +1,13 @@
 package com.project.voa.service;
 
 import com.project.voa.domain.Version;
+import com.project.voa.dto.VersionModel;
 import com.project.voa.repository.VersionRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,5 +30,13 @@ public class VersionService {
 	public void deleteVersion(final long id) {
 		Version version = versionRepository.findById(id).orElseThrow(EntityNotFoundException::new);
 		versionRepository.delete(version);
+	}
+
+	/**
+	 * 버전들 조회
+	 * @return
+	 */
+	public List<VersionModel> getVersions() {
+		return VersionModel.versionsToVersionModels((List<Version>) versionRepository.findAll());
 	}
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,3 +4,7 @@ VALUES ('버그', now(), now()),
        ('작업', now(), now()),
        ('개선사항', now(), now()),
        ('스토리', now(), now());
+
+-- admin 자동 추가
+INSERT INTO user_info (user_name, user_email, password, profile)
+VALUES ('admin', 'admin@email.com', '123', '')


### PR DESCRIPTION
[작업 내용]
- label들 조회하는 API 구현
- 불필요한 어노테이션 제거
- 필요한 리턴값만 담은 LabelModel 추가

[추가작업]
- 버전들을 조회하는 API 구현
- 필요한 리턴값만 담은 VersionModel 추가
- data.sql에 user_info 데이터 삽입 쿼리문 추가(추가하는 user_info : admin)