### PR TITLE
task/[프론트] 이슈 추가 및 편집 할 때 레이블, 버전 다이얼로그 추가 #50

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -415,6 +415,11 @@ tr {
     max-height: 150px;
 }
 
+.issue-new-version-wrap,
+.issue-new-label-wrap {
+    margin-top: -20px;
+}
+
 .issue-version-select-item,
 .issue-label-select-item {
     margin: 3px 0px 3px 5px;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -401,3 +401,26 @@ tr {
  #edit-issue .issue-wrap {
     background-color: ghostwhite;
  }
+
+.issue-new-version-wrap,
+.issue-new-label-wrap,
+.issue-edit-version-wrap,
+.issue-edit-label-wrap {
+    position: absolute;
+    background-color: white;
+    border: 1px solid silver;
+    width: 509px;
+    margin-top: 1px;
+    overflow-y: auto;
+    max-height: 150px;
+}
+
+.issue-version-select-item,
+.issue-label-select-item {
+    margin: 3px 0px 3px 5px;
+}
+
+.issue-version-select-item:hover,
+.issue-label-select-item:hover {
+    background-color: silver;
+}

--- a/src/main/resources/static/src/IssueManager.ts
+++ b/src/main/resources/static/src/IssueManager.ts
@@ -118,9 +118,9 @@ export class IssueManager {
     }
 
     public showVersions(): void {
-        //TODO request
+        const type: string = (event.target as HTMLInputElement).getAttribute('data-type');
         const successFunc: Function = (versions: any) => {
-            this.render.rendVersions(versions);
+            this.render.rendVersions(versions, type);
         }
 
         const errorFunc: Function = (res: Response) => {
@@ -130,8 +130,15 @@ export class IssueManager {
     }
 
     public showLabels(): void {
-        //TODO request
-        this.render.rendLabels();
+        const type: string = (event.target as HTMLInputElement).getAttribute('data-type');
+        const successFunc: Function = (labels: any) => {
+            this.render.rendLabels(labels, type);
+        }
+
+        const errorFunc: Function = (res: Response) => {
+            console.log(res);
+        }
+        this.request.get('labels', {}, successFunc, errorFunc);
     }
 
     public updateIssue(): void {

--- a/src/main/resources/static/src/Render.ts
+++ b/src/main/resources/static/src/Render.ts
@@ -1,5 +1,7 @@
 import { NewIssue } from './model/NewIssue';
 import { RequestHelper } from './request/RequestHelper';
+import { Utils } from './util/Utils';
+
 export class Render {
     private request: RequestHelper = new RequestHelper();
 
@@ -120,19 +122,51 @@ export class Render {
         document.getElementsByClassName('issue-todo-item-wrap')[0].appendChild(elIssueCard);
     }
 
-    private clickVersionItem(): void {
-        const elVersionSelect: HTMLDivElement = document.getElementById('issue-edit-version-select') as HTMLDivElement;
-        const elVersionContent: HTMLDivElement = elVersionSelect.querySelector('.issue-version-select-item-wrap');
-        const elSpan: HTMLSpanElement = document.createElement('span');
+    /**
+     * 이슈 생성 또는 편집 다이얼로그에서 버전을 클릭하면 추가
+     */
+    private clickVersionItem(type: string): void {
+        const elInputVersion: HTMLInputElement = document.querySelector(`#issue-${type}-version-input`);
+        const selectVersion: string = (event.target as HTMLDivElement).textContent;
+        let value: string = elInputVersion.value;
 
-        elSpan.textContent = 'aaa';
-        elVersionSelect.appendChild(elSpan);
-        elVersionContent.classList.add('hide');
+        if (!value) {
+            value += selectVersion;
+        } else {
+            value += `,${selectVersion}`;
+        }
+
+        elInputVersion.value = value;
+        Utils.removeElement(document.querySelector('.issue-version-wrap'));
     }
 
-    public rendVersions(versions: any): void {
-        const elVersionSelect: HTMLDivElement = document.getElementById('issue-edit-version-select') as HTMLDivElement;
-        const elVersionContent: HTMLDivElement = elVersionSelect.querySelector('.issue-version-select-item-wrap');
+    /**
+     * 이슈 생성 또는 편집 다이얼로그에서 라벨을 클릭하면 추가
+     */
+    private clickLabelItem(type: string): void {
+        const elInputLabel: HTMLInputElement = document.querySelector(`#issue-${type}-label-input`);
+        const selectLabel: string = (event.target as HTMLDivElement).textContent;
+        let value: string = elInputLabel.value;
+
+        if (!value) {
+            value += selectLabel;
+        } else {
+            value += `,${selectLabel}`;
+        }
+
+        elInputLabel.value = value;
+        Utils.removeElement(document.querySelector('.issue-label-wrap'));
+    }
+
+    /**
+     * 이슈 생성 또는 편집 다이얼로그에서 버전을 그립니다.
+     * @param versions 
+     */
+    public rendVersions(versions: any, type: string): void {
+        Utils.removeElement(document.querySelector(`.issue-${type}-version-wrap`));
+
+        const elVersionContent: HTMLDivElement = document.createElement('div');
+        elVersionContent.classList.add(`issue-${type}-version-wrap`)
         elVersionContent.innerHTML = '';
 
         versions.forEach((version: any) => {
@@ -140,19 +174,36 @@ export class Render {
             elNewVersion.textContent = version.name;
             elNewVersion.classList.add('issue-version-select-item');
             elNewVersion.setAttribute('data-version-id', version.id);
-            elNewVersion.addEventListener('click', this.clickVersionItem);
+            elNewVersion.addEventListener('click', this.clickVersionItem.bind(this, type));
 
             elVersionContent.appendChild(elNewVersion);
         });
 
-        document.getElementById('issue-edit-label-select').classList.add('hide');
-        document.getElementById('issue-edit-version-select').classList.remove('hide');
-        document.getElementById('issue-edit-version-select-item-wrap').classList.remove('hide');
+        document.querySelector(`#issue-${type}-version-input`).parentElement.appendChild(elVersionContent);
     }
 
-    public rendLabels(): void {
-        document.getElementById('issue-version-select').classList.add('hide');
-        document.getElementById('issue-label-select').classList.remove('hide');
+    /**
+     * 이슈 생성 또는 편집 다이얼로그에서 라벨을 그립니다.
+     * @param versions
+     */
+    public rendLabels(labels: any, type: string): void {
+        Utils.removeElement(document.querySelector(`.issue-${type}-label-wrap`));
+
+        const elLabelsContent: HTMLDivElement = document.createElement('div');
+        elLabelsContent.classList.add(`issue-${type}-label-wrap`)
+        elLabelsContent.innerHTML = '';
+
+        labels.forEach((version: any) => {
+            const elNewLabels: HTMLDivElement = document.createElement('div');
+            elNewLabels.textContent = version.name;
+            elNewLabels.classList.add('issue-label-select-item');
+            elNewLabels.setAttribute('data-version-id', version.id);
+            elNewLabels.addEventListener('click', this.clickLabelItem.bind(this, type));
+
+            elLabelsContent.appendChild(elNewLabels);
+        });
+
+        document.querySelector(`#issue-${type}-label-input`).parentElement.appendChild(elLabelsContent);
     }
 
     /**

--- a/src/main/resources/static/src/index.ts
+++ b/src/main/resources/static/src/index.ts
@@ -1,5 +1,6 @@
 import { Factory } from "./Factory";
 import { Render } from "./Render";
+import { Utils } from "./util/Utils";
 
 document.addEventListener('DOMContentLoaded', () => {
     const factory = new Factory();
@@ -16,8 +17,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const cmd: string = target.getAttribute('data-cmd');
     
         if (!that || !cmd) {
-            document.getElementById('issue-version-select').classList.add('hide');
-            document.getElementById('issue-label-select').classList.add('hide');
+            Utils.removeElement(document.querySelector('.issue-new-version-wrap'));
+            Utils.removeElement(document.querySelector('.issue-new-label-wrap'));
+            Utils.removeElement(document.querySelector('.issue-edit-version-wrap'));
+            Utils.removeElement(document.querySelector('.issue-edit-label-wrap'));
             return;
         }
 

--- a/src/main/resources/static/src/util/Utils.ts
+++ b/src/main/resources/static/src/util/Utils.ts
@@ -1,0 +1,17 @@
+export class Utils {
+    static hideElement(el: any): void {
+        el.classList.add('hide');
+    }
+    
+    static showElement(el: any): void {
+        el.classList.remove('hide');
+    }
+
+    static removeElement(el: any): void {
+        if (!el) {
+            return;
+        }
+
+        el.remove();
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -111,10 +111,7 @@
                 <span class="issue-tiny-text issue-title-align">버전</span>
             </div>
             <div class="issue-content-wrap">
-                <input id="issue-version-input" class="issue-input" type="text" data-obj="issueManager" data-cmd="showVersions" autocomplete="off"/>
-                <div id="issue-version-select" class="hide">
-                    <div class="issue-version-select-item">WIP</div>
-                </div>
+                <input id="issue-new-version-input" class="issue-input" type="text" data-type="new" data-obj="issueManager" data-cmd="showVersions" autocomplete="off"/>
                 <span class="issue-content-desc">키보드 입력을 시작해서 사용 가능한 목록을 가져오거나 아래를 눌러 선택하세요.</span>
             </div>
         </div>
@@ -159,10 +156,7 @@
                 <span class="issue-tiny-text issue-title-align">라벨</span>
             </div>
             <div class="issue-content-wrap">
-                <input id="issue-label-input" class="issue-input" type="text" data-obj="issueManager" data-cmd="showLabels" autocomplete="off"/>
-                <div id="issue-label-select" class="hide">
-                    <div class="issue-label-select-item">WIP</div>
-                </div>
+                <input id="issue-new-label-input" class="issue-input" type="text" data-type="new" data-obj="issueManager" data-cmd="showLabels" autocomplete="off"/>
                 <span class="issue-content-desc">새 라벨을 만들거나 찾으려면 키보드 입력을 시작하세요. 추천 라벨을 보시려면 목록을 여세요.</span>
             </div>
         </div>
@@ -238,10 +232,7 @@
                 <span class="issue-tiny-text issue-title-align">버전</span>
             </div>
             <div class="issue-content-wrap">
-                <input id="issue-edit-version-input" class="issue-input" type="text" data-obj="issueManager" data-cmd="showVersions" autocomplete="off"/>
-                <div id="issue-edit-version-select" class="hide">
-                    <div class="issue-version-select-item">WIP</div>
-                </div>
+                <input id="issue-edit-version-input" class="issue-input" type="text" data-type="edit" data-obj="issueManager" data-cmd="showVersions" autocomplete="off"/>
             </div>
         </div>
         <div class="issue-field-wrap">
@@ -283,10 +274,7 @@
                 <span class="issue-tiny-text issue-title-align">라벨</span>
             </div>
             <div class="issue-content-wrap">
-                <input id="issue-edit-label-input" class="issue-input" type="text" data-obj="issueManager" data-cmd="showLabels" autocomplete="off"/>
-                <div id="issue-edit-label-select" class="hide">
-                    <div class="issue-label-select-item">WIP</div>
-                </div>
+                <input id="issue-edit-label-input" class="issue-input" type="text" data-type="edit" data-obj="issueManager" data-cmd="showLabels" autocomplete="off"/>
             </div>
         </div>
         <div class="issue-field-wrap">


### PR DESCRIPTION
- 이슈 추가 및 편집 다이얼로그에서 레이블, 버전 영역을 클릭하면 서버로부터 데이터를 받아서 렌더링합니다.
- 현재는 레이블과 버전을 직접 입력 시 ','쉼표를 추가해 주어야 합니다.
- 이미 존재하는 레이블과 버전을 클릭하여 추가하면 뒤에 ','가 자동으로 삽입됩니다.