### PR TITLE
task/첨부파일명 중복 허용 작업 #61

### DIFF
--- a/src/main/java/com/project/voa/domain/Attachment.java
+++ b/src/main/java/com/project/voa/domain/Attachment.java
@@ -1,12 +1,10 @@
 package com.project.voa.domain;
 
 import jakarta.persistence.*;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
@@ -22,10 +20,14 @@ public class Attachment {
 	@Column(nullable = false)
 	private String name;
 
+	@Column(nullable = false)
+	private String uuidName;
+
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	public Attachment(String name) {
+	public Attachment(String name, String savedFileName) {
 		this.name = name;
+		this.uuidName = savedFileName;
 	}
 }

--- a/src/main/java/com/project/voa/domain/Attachment.java
+++ b/src/main/java/com/project/voa/domain/Attachment.java
@@ -26,8 +26,8 @@ public class Attachment {
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	public Attachment(String name, String savedFileName) {
+	public Attachment(String name, String uuidName) {
 		this.name = name;
-		this.uuidName = savedFileName;
+		this.uuidName = uuidName;
 	}
 }


### PR DESCRIPTION
[작업 내용]
- 중복되는 첨부파일명 업로드 허용
- 실제 업로드되는 파일명은 UUID로 구분하여 저장
- DB에 UUID로 저장하는 파일명 컬럼 추가